### PR TITLE
Enable deselecting existing IoT Hub during deploy

### DIFF
--- a/createUiDefinition.json
+++ b/createUiDefinition.json
@@ -30,11 +30,17 @@
             }
           },
           {
+            "name": "reuseExistingIotHub",
+            "type": "Microsoft.Common.CheckBox",
+            "label": "Reuse existing Azure IoT Hub"
+          },
+          {
             "name": "existingIotHubSelector",
             "type": "Microsoft.Solutions.ResourceSelector",
             "label": "Existing Azure IoT Hub",
-            "toolTip": "Select an existing Azure IoT Hub to reuse (for instance, if one is available from a previous CFS deployment). Leave empty to create a new Azure IoT Hub.",
+            "toolTip": "Select an existing Azure IoT Hub to reuse (for instance, if one is available from a previous CFS deployment).",
             "resourceType": "Microsoft.Devices/IotHubs",
+            "visible": "[basics('mainSection').reuseExistingIotHub]",
             "options": {
               "filter": {
                 "subscription": "onBasics",


### PR DESCRIPTION
Add a checkbox (unchecked by default) to let users choose to use an existing Azure IoT Hub. The selector becomes visible when the checkbox is checked.

If an IoT Hub was selected and the checkbox gets deselected, the selected IoT Hub value will not be passed on to the ARM deployment.