### PR TITLE
Fix ASAQL line endings during build

### DIFF
--- a/scripts/Build-ARMTemplate.ps1
+++ b/scripts/Build-ARMTemplate.ps1
@@ -24,7 +24,7 @@ function Set-LineEndings($Value) {
 }
 
 function Set-FileLineEndings($Path) {
-    foreach ($itemPath in (Get-ChildItem -Path $Path)) {
+    foreach ($itemPath in (Get-ChildItem -Recurse -Path $Path)) {
         $content = Get-Content -Raw -Path $itemPath
 
         $contentNewlinesSanitized = Set-LineEndings -Value $content


### PR DESCRIPTION
Copied the `Get-ChildItem` code from the Logic Apps' line-ending sanitizer. However, `*.asaql` files are not in the root directory so we need `-Recurse` switch enabled.