### PR TITLE
Bump Bicep version to 0.8.9

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.8.2.30886",
-      "templateHash": "17775749501408173433"
+      "version": "0.8.9.13224",
+      "templateHash": "6211768419858682532"
     }
   },
   "parameters": {

--- a/main.bicep
+++ b/main.bicep
@@ -306,7 +306,7 @@ resource streamAnalyticsJobs 'Microsoft.StreamAnalytics/streamingjobs@2021-10-01
             properties: {
               functionAppName: asaToRedisFuncSite.name
               functionName: 'AzureStreamAnalyticsToRedis'
-              apiKey: listKeys('${asaToRedisFuncSite.id}/host/default', '2021-02-01').functionKeys['default']
+              apiKey: listKeys('${asaToRedisFuncSite.id}/host/default', '2021-02-01').functionKeys.default
             }
           }
         }


### PR DESCRIPTION
Also fix Bicep warning (`['default']` => `.default`):

```
main.bicep(309,99) : Warning prefer-unquoted-property-names:
  Property names that are valid identifiers should be declared
  without quotation marks and accessed using dot notation.
  [https://aka.ms/bicep/linter/prefer-unquoted-property-names]
```