### PR TITLE
Disallow basic auth for SCM and FTP on Redix proxy Az Function App

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.16.2.56959",
-      "templateHash": "15575609601188660018"
+      "version": "0.17.1.54307",
+      "templateHash": "1811282267606797026"
     }
   },
   "parameters": {
@@ -126,6 +126,28 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', format('msdyn-iiot-sdi-servicebus-{0}', variables('uniqueIdentifier')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+      "apiVersion": "2021-03-01",
+      "name": "[format('{0}/{1}', format('msdyn-iiot-sdi-functionapp-{0}', variables('uniqueIdentifier')), 'ftp')]",
+      "properties": {
+        "allow": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', format('msdyn-iiot-sdi-functionapp-{0}', variables('uniqueIdentifier')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+      "apiVersion": "2021-03-01",
+      "name": "[format('{0}/{1}', format('msdyn-iiot-sdi-functionapp-{0}', variables('uniqueIdentifier')), 'scm')]",
+      "properties": {
+        "allow": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', format('msdyn-iiot-sdi-functionapp-{0}', variables('uniqueIdentifier')))]"
       ]
     },
     {

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.17.1.54307",
-      "templateHash": "1811282267606797026"
+      "templateHash": "10491854958123641543"
     }
   },
   "parameters": {
@@ -132,6 +132,7 @@
       "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
       "apiVersion": "2021-03-01",
       "name": "[format('{0}/{1}', format('msdyn-iiot-sdi-functionapp-{0}', variables('uniqueIdentifier')), 'ftp')]",
+      "location": "[variables('resourcesLocation')]",
       "properties": {
         "allow": false
       },
@@ -143,6 +144,7 @@
       "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
       "apiVersion": "2021-03-01",
       "name": "[format('{0}/{1}', format('msdyn-iiot-sdi-functionapp-{0}', variables('uniqueIdentifier')), 'scm')]",
+      "location": "[variables('resourcesLocation')]",
       "properties": {
         "allow": false
       },

--- a/main.bicep
+++ b/main.bicep
@@ -210,6 +210,8 @@ resource asaToRedisFuncSite 'Microsoft.Web/sites@2021-03-01' = {
 
   resource disallowBasicAuthForFtp 'basicPublishingCredentialsPolicies' = {
     name: 'ftp'
+    #disable-next-line BCP187 // See https://github.com/Azure/bicep/issues/784#issuecomment-1410279498
+    location: resourcesLocation
     properties: {
       allow: false
     }
@@ -217,6 +219,8 @@ resource asaToRedisFuncSite 'Microsoft.Web/sites@2021-03-01' = {
 
   resource disallowBasicAuthForScm 'basicPublishingCredentialsPolicies' = {
     name: 'scm'
+    #disable-next-line BCP187 // See https://github.com/Azure/bicep/issues/784#issuecomment-1410279498
+    location: resourcesLocation
     properties: {
       allow: false
     }
@@ -421,7 +425,7 @@ resource logicApp2ServiceBusConnection 'Microsoft.Web/connections@2016-06-01' = 
   location: resourcesLocation
   properties: {
     displayName: 'msdyn-iiot-sdi-servicebusconnection-${uniqueIdentifier}'
-    #disable-next-line BCP089 Bicep does not know the parameterValueSet property for connections
+    #disable-next-line BCP089 // Bicep does not know the parameterValueSet property for connections
     parameterValueSet: {
       name: 'managedIdentityAuth'
       values: {
@@ -442,7 +446,7 @@ resource logicApp2StorageAccountConnection 'Microsoft.Web/connections@2016-06-01
   location: resourcesLocation
   properties: {
     displayName: 'msdyn-iiot-sdi-storageaccountbusconnection-${uniqueIdentifier}'
-    #disable-next-line BCP089 Bicep does not know the parameterValueSet property for connections
+    #disable-next-line BCP089 // Bicep does not know the parameterValueSet property for connections
     parameterValueSet: {
       name: 'managedIdentityAuth'
       values: {}

--- a/main.bicep
+++ b/main.bicep
@@ -208,6 +208,20 @@ resource asaToRedisFuncSite 'Microsoft.Web/sites@2021-03-01' = {
     }
   }
 
+  resource disallowBasicAuthForFtp 'basicPublishingCredentialsPolicies' = {
+    name: 'ftp'
+    properties: {
+      allow: false
+    }
+  }
+
+  resource disallowBasicAuthForScm 'basicPublishingCredentialsPolicies' = {
+    name: 'scm'
+    properties: {
+      allow: false
+    }
+  }
+
   resource deployAsaToRedisFunctionFromGitHub 'sourcecontrols' = {
     name: 'web'
     kind: 'gitHubHostedTemplate'


### PR DESCRIPTION
This is a security recommendation.

Since SCM (Kudu) can be accessed authenticating via AAD, basic auth is not needed. For FTP, that is also not needed since deployment happens via Git deployment in the Bicep template.