### PR TITLE
Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   validate-bicep-builds:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/Dynamics365-Sensor-Data-Intelligence-ARMDeployments/security/code-scanning/2](https://github.com/microsoft/Dynamics365-Sensor-Data-Intelligence-ARMDeployments/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root (right after the `on` section and before `jobs`) so it applies to all jobs unless overridden. For this workflow, the least-privilege baseline is:

- `contents: read`

This preserves current functionality while constraining `GITHUB_TOKEN`. No imports, methods, or extra definitions are needed since this is YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
